### PR TITLE
Add Topic Extraction from Story URLs

### DIFF
--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -7,6 +7,9 @@ The pipeline tracks and stores information about the top 200 stories on the Hack
 
 All requirements are stored in the requirements.txt file.
 
+An API key for OpenAI GPT API is required for the transform script to generate topics.
+This should be stored in a `.env` file as `OPENAI_API_KEY`.
+
 ## `extract.py`
 
 This script is for extracting important information about the stories directly from the HN API.
@@ -19,4 +22,5 @@ This script is for extracting important information about the stories directly f
 
 This script formats the extracted information and removes invalid entries.
 
+- `generate_topic` makes use of the openai library which provides access to the GPT API. It categorises a URL based on a set of given topics which have been decided upon by analysis of 200 urls with GPT4. It does this by making a request to the API with these specific instructions.
 - `clean_dataframe` takes the data from the csv file as a pandas DataFrame so that it can be manipulated efficiently. Once all edits have been made it returns the cleaned dataframe.

--- a/pipeline/requirements.txt
+++ b/pipeline/requirements.txt
@@ -1,2 +1,5 @@
 requests
 pandas
+pandarallel
+openai
+python-dotenv

--- a/pipeline/transform.py
+++ b/pipeline/transform.py
@@ -1,6 +1,45 @@
 """This script cleans the data collected from the Hacker News API."""
+from os import environ
+from dotenv import load_dotenv
 import pandas as pd
-from datetime import datetime
+
+from openai import OpenAI
+from pandarallel import pandarallel
+
+load_dotenv()
+VALID_TOPICS = ("1","2","3","4","5","6","7","8","9","10","11")
+
+pandarallel.initialize(progress_bar=True)
+
+
+client = OpenAI(
+    api_key = environ["OPENAI_API_KEY"]
+)
+
+
+def generate_topic(story_url: str) -> str:
+    completion = client.chat.completions.create(
+    model="gpt-3.5-turbo",
+    messages=[
+        {"role": "system",
+         "content": """You are a classifying bot that can categorise urls into only these categories by returning the corresponding number:
+         1. Programming & Software Development
+         2. Game Development
+         3. Algorithms & Data Structures
+         4. Web Development & Browser Technologies
+         5. Computer Graphics & Image Processing
+         6. Operating Systems & Low-level Programming
+         7. Science & Research Publications
+         8. Literature & Book Reviews
+         9. Artificial Intelligence & Machine Learning
+         10. News & Current Affairs.
+         11. Miscellaneous & Interesting Facts"""},
+        {"role": "user",
+         "content": f"""Categorise this url into one of the listed categories: {story_url}.
+         Only state the category number and nothing else. Ensure your only output is a number."""}
+    ]
+    )
+    return completion.choices[0].message.content
 
 
 def clean_dataframe(stories_df: pd.DataFrame) -> pd.DataFrame:
@@ -12,8 +51,11 @@ def clean_dataframe(stories_df: pd.DataFrame) -> pd.DataFrame:
                                             "url": "story_url"})
     stories_df = stories_df[stories_df.type == "story"]
     stories_df = stories_df.drop(columns="type")
-
+    stories_df["topic_id"] = stories_df["story_url"].parallel_apply(generate_topic)
+    stories_df.loc[~stories_df["topic_id"].isin(VALID_TOPICS), "topic_id"] = None
+    
     return stories_df
+
 
 
 if __name__ == "__main__":

--- a/pipeline/transform.py
+++ b/pipeline/transform.py
@@ -1,4 +1,4 @@
-"""This script cleans the data collected from the Hacker News API."""
+"""This script cleans & builds upon the data collected from the Hacker News API."""
 from os import environ
 from dotenv import load_dotenv
 import pandas as pd

--- a/pipeline/transform.py
+++ b/pipeline/transform.py
@@ -6,11 +6,12 @@ import pandas as pd
 from openai import OpenAI
 from pandarallel import pandarallel
 
+
 load_dotenv()
-VALID_TOPICS = ("1","2","3","4","5","6","7","8","9","10","11")
+
+VALID_TOPIC_IDS = ("1","2","3","4","5","6","7","8","9","10","11")
 
 pandarallel.initialize(progress_bar=True)
-
 
 client = OpenAI(
     api_key = environ["OPENAI_API_KEY"]
@@ -18,6 +19,7 @@ client = OpenAI(
 
 
 def generate_topic(story_url: str) -> str:
+    """Finds the most suitable topic for a url from a predefined list of topics with the OpenAI API."""
     completion = client.chat.completions.create(
     model="gpt-3.5-turbo",
     messages=[
@@ -36,9 +38,7 @@ def generate_topic(story_url: str) -> str:
          11. Miscellaneous & Interesting Facts"""},
         {"role": "user",
          "content": f"""Categorise this url into one of the listed categories: {story_url}.
-         Only state the category number and nothing else. Ensure your only output is a number."""}
-    ]
-    )
+         Only state the category number and nothing else. Ensure your only output is a number."""}])
     return completion.choices[0].message.content
 
 
@@ -52,10 +52,8 @@ def clean_dataframe(stories_df: pd.DataFrame) -> pd.DataFrame:
     stories_df = stories_df[stories_df.type == "story"]
     stories_df = stories_df.drop(columns="type")
     stories_df["topic_id"] = stories_df["story_url"].parallel_apply(generate_topic)
-    stories_df.loc[~stories_df["topic_id"].isin(VALID_TOPICS), "topic_id"] = None
-    
+    stories_df.loc[~stories_df["topic_id"].isin(VALID_TOPIC_IDS), "topic_id"] = None
     return stories_df
-
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- The transform script has been updated to be able to extract the topic of a story from a predefined list of topics.
- The predefined list was generated by feeding GPT4 a list of 200 URLs from Hacker News API and asking it to produce 10 most common topics, I added 11 - Miscellaneous & Interesting Facts to account for outliers.
- To run this you will need an `OPENAI_API_KEY` in your `.env` which you can ask me (Jack) for.
- The generate_topic function basically asks GPT API to categorise a url (it can access the site I believe) into one of the 11 categories and return the corresponding number.
- I have used parallel_apply from pandarallel to apply it to each URL in the dataframe and create a new column called "topic_id".
