### PR TITLE
Add topics table to schema & seed it

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -50,7 +50,7 @@ CREATE TABLE records (
   record_id INT GENERATED ALWAYS AS IDENTITY, 
   story_id INT NOT NULL,
   score SMALLINT NOT NULL,
-  comments INT NOT NULL,
+  comments SMALLINT NOT NULL,
   record_time TIMESTAMP NOT NULL DEFAULT current_timestamp,
   PRIMARY KEY (record_id),
   CONSTRAINT fk_story

--- a/schema.sql
+++ b/schema.sql
@@ -4,8 +4,31 @@ DROP DATABASE IF EXISTS technews;
 
 CREATE DATABASE technews;
 \c technews
+DROP TABLE IF EXISTS topics;
 DROP TABLE IF EXISTS stories;
 DROP TABLE IF EXISTS records;
+
+
+CREATE TABLE topics (
+  topic_id INT GENERATED ALWAYS AS IDENTITY,
+  name VARCHAR(250),
+  PRIMARY KEY (topic_id)
+);
+
+
+INSERT INTO topics (name)
+VALUES
+('Programming & Software Development'),
+('Game Development'),
+('Algorithms & Data Structures'),
+('Web Development & Browser Technologies'),
+('Computer Graphics & Image Processing'),
+('Operating Systems & Low-level Programming'),
+('Science & Research Publications'),
+('Literature & Book Reviews'),
+('Artificial Intelligence & Machine Learning'),
+('News & Current Affairs'),
+('Miscellaneous & Interesting Facts');
 
 
 CREATE TABLE stories (
@@ -14,7 +37,12 @@ CREATE TABLE stories (
   author VARCHAR(100) NOT NULL,
   story_url VARCHAR(500),
   creation_date TIMESTAMP NOT NULL,
-  PRIMARY KEY (story_id)
+  topic_id INT,
+  PRIMARY KEY (story_id),
+  CONSTRAINT fk_topic
+    FOREIGN KEY (topic_id)
+    REFERENCES topics(topic_id)
+    ON DELETE CASCADE
   );
 
 


### PR DESCRIPTION
Added a new table to the schema to store topics as a separate table.
Topic is referenced in the story table so that we can track trending topics out of all stories.