### PR TITLE
Minor pipeline cleaning

### DIFF
--- a/pipeline/extract.py
+++ b/pipeline/extract.py
@@ -6,6 +6,7 @@ from requests import get, exceptions
 from dotenv import load_dotenv
 
 BASE_URL = "https://hacker-news.firebaseio.com/v0/"
+STORY_COUNT = 200
 
 
 def get_top_stories(count: int) -> list:
@@ -41,11 +42,3 @@ def generate_dataframe(row_count: int) -> None:
     story_ids = get_top_stories(row_count)
     all_stories = [extract_story_info(id) for id in story_ids]
     return pd.DataFrame(all_stories)
-
-
-if __name__ == "__main__":
-    load_dotenv()
-    STORY_COUNT = 200
-
-    stories_df = generate_dataframe(STORY_COUNT)
-    stories_df.to_csv("extracted_stories.csv", index=False)

--- a/pipeline/load.py
+++ b/pipeline/load.py
@@ -62,10 +62,3 @@ def upload_latest_data(df: pd.DataFrame, connection) -> None:
         cursor.executemany(
             record_query, records_insert)
         connection.commit()
-
-
-if __name__ == "__main__":
-
-    data = pd.read_csv('clean_all_stories.csv')
-    conn = get_db_connection()
-    upload_latest_data(data, conn)

--- a/pipeline/transform.py
+++ b/pipeline/transform.py
@@ -82,10 +82,3 @@ def clean_dataframe(stories_df: pd.DataFrame) -> pd.DataFrame:
         VALID_TOPIC_IDS), "topic_id"] = None
 
     return stories_df
-
-
-if __name__ == "__main__":
-
-    story_df = pd.read_csv("extracted_stories.csv", index_col=False)
-    clean_stories = clean_dataframe(story_df)
-    clean_stories.to_csv("transformed_stories.csv", index=False)


### PR DESCRIPTION
Figured out why theres not always 200 stories - its because there is usually 1 / 2 job postings that get cleaned from the df. Doesnt seem like an issue for now, so I just updated the Lambda on AWS to include latest updates. I cleaned the pipeline files to remove the main blocks too as they didnt feel necessary.